### PR TITLE
Use PIL instead of temp image folder + Improved settings.json

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,18 +1,16 @@
 {
     "active": "Danbooru",
     "negativeprompt": "lowres, bad anatomy, bad hands, text, error, missing fingers, extra digit, fewer digits, cropped, worst quality, low quality, normal quality, jpeg artifacts, signature, watermark, username, blurry, artist name",
-    "boorus": [
-        {
-            "name": "Danbooru",
+    "boorus": {
+        "Danbooru": {
             "host": "https://danbooru.donmai.us",
             "username": "",
             "apikey": ""
         },
-        {
-            "name": "AIBooru",
+        "AIBooru": {
             "host": "https://aibooru.space",
             "username": "",
             "apikey": ""
         }
-    ]
+    }
 }


### PR DESCRIPTION
Images are now stored in memory instead of saved to tempimage folder. This fixes issue on Linux where images were not saves in tempimage folder but instead ./tempimage\temp0.jpg" with "\\" directory separator in filename.

Improved settings .json.
Before accessing Danbooru's username in dict settings would be done with

for booru in settings["boorus"]:
  if booru["name"] == "Danbooru":
    return booru["username"]

now is 

settings["boorus"]["Danbooru"]["username"]