### PR TITLE
e621, e6ai support. Fix 403 error

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -13,6 +13,18 @@
             "host": "https://aibooru.space",
             "username": "",
             "apikey": ""
+        },
+        {
+            "name": "e621",
+            "host": "https://e621.net/",
+            "username": "",
+            "apikey": ""
+        },
+        {
+            "name": "e6ai",
+            "host": "https://e6ai.net/",
+            "username": "",
+            "apikey": ""
         }
     ]
 }


### PR DESCRIPTION
I added e621 and e6ai support #10 and I fixed the 403 errors that would somtimes randomly occur.
API key needed to scrape from e621 and e6ai (which can be gotten from their respective account pages).

I don't usually program in python, so its probably not be the best implementation, but it works. Feel free to merge or just use as a reference.